### PR TITLE
Display token address on landing page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -54,6 +54,14 @@ export default function LandingPage() {
               </a>
             )}
           </div>
+          <div className="mt-6">
+            <p className="text-xs font-medium uppercase tracking-wider text-zinc-500">
+              Token Address
+            </p>
+            <p className="mt-1 font-mono text-sm text-zinc-400 break-all">
+              {config.token.address}
+            </p>
+          </div>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
Added a new section to the landing page that displays the token address from the configuration.

## Changes
- Added a new UI section below the existing content that shows the token address
- Displays a labeled "Token Address" header with consistent styling (uppercase, small font, muted color)
- Token address is rendered in monospace font with word-break styling to handle long addresses gracefully
- Uses the existing `config.token.address` value for the displayed address

## Implementation Details
- Follows the existing design system with consistent spacing (mt-6), typography, and color scheme (zinc-500/400)
- Uses `break-all` class to ensure long token addresses wrap properly on smaller screens
- Maintains visual hierarchy with uppercase label and secondary text styling

https://claude.ai/code/session_01Sp1hbGoz2ZigsBMtUyeSqh