### PR TITLE
Add token address display to landing page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -54,6 +54,16 @@ export default function LandingPage() {
               </a>
             )}
           </div>
+          <div className="mt-6">
+            <a
+              href={`https://solscan.io/token/${config.token.address}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-block font-mono text-sm text-zinc-400 break-all transition-colors hover:text-green-400"
+            >
+              {config.token.address}
+            </a>
+          </div>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
Added a token address section to the landing page that displays the token contract address with a direct link to Solscan for easy verification and exploration.

## Changes
- **Landing Page Enhancement**: Added a new "Token Address" section below existing information that displays the token address from config with a clickable link to Solscan
  - Styled consistently with existing sections using the same typography and spacing patterns
  - Link opens in a new tab with security attributes (`target="_blank"` and `rel="noopener noreferrer"`)
  - Address text uses monospace font for clarity and includes hover effect (green highlight)
  - Text wrapping enabled for responsive display on smaller screens

## Implementation Details
- The token address is sourced from `config.token.address`
- Solscan link format: `https://solscan.io/token/{address}`
- Maintains visual consistency with existing UI elements (text sizing, colors, spacing)