### PR TITLE
Configure treasury wallet address

### DIFF
--- a/src/giggybank.config.ts
+++ b/src/giggybank.config.ts
@@ -17,7 +17,7 @@ export const config: ProjectConfig = {
     bagsUrl: 'https://bags.fm/coin/GefTGjFnJGW9PM93Ycb5RrHKiH1gPbz2Szag1mLBBAGS',
   },
   treasury: {
-    wallet: 'PLACEHOLDER_TREASURY_WALLET',
+    wallet: '2FCwMoEYKFVe93FNMApYtwCEdCboCPEYnS5JSjvw6kRZ',
     solscanUrl: 'https://solscan.io/account/2FCwMoEYKFVe93FNMApYtwCEdCboCPEYnS5JSjvw6kRZ',
   },
   team: {


### PR DESCRIPTION
## Summary
Replace the placeholder treasury wallet address with the actual production wallet address.

## Changes
- Updated `treasury.wallet` configuration from `PLACEHOLDER_TREASURY_WALLET` to `2FCwMoEYKFVe93FNMApYtwCEdCboCPEYnS5JSjvw6kRZ`
- The corresponding Solscan URL was already configured with this wallet address

## Details
This change finalizes the treasury configuration by replacing the temporary placeholder with the actual Solana wallet address that will receive treasury funds.
