### PR TITLE
Add TypeScript build info to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 .env.local
 .vercel
 .DS_Store
+*.tsbuildinfo


### PR DESCRIPTION
## Summary
Updated the `.gitignore` file to exclude TypeScript build cache files from version control.

## Changes
- Added `*.tsbuildinfo` to `.gitignore` to prevent TypeScript incremental build information files from being committed to the repository

## Details
TypeScript generates `.tsbuildinfo` files when using incremental compilation mode. These files are build artifacts that should not be tracked in version control as they are:
- Automatically regenerated during builds
- Machine and environment-specific
- Not needed for source code management