### PR TITLE
Update bags.fm URLs to remove /coin path segment

### DIFF
--- a/src/app/framework/page.tsx
+++ b/src/app/framework/page.tsx
@@ -141,7 +141,7 @@ export const config = {
   token: {
     symbol: 'YOURTOKEN',
     address: '<solana-mint-address>',
-    bagsUrl: 'https://bags.fm/coin/<address>',
+    bagsUrl: 'https://bags.fm/<address>',
   },
   treasury: {
     wallet: '<treasury-wallet-address>',

--- a/src/giggybank.config.ts
+++ b/src/giggybank.config.ts
@@ -14,7 +14,7 @@ export const config: ProjectConfig = {
   token: {
     symbol: 'GIGGYBANK',
     address: 'GefTGjFnJGW9PM93Ycb5RrHKiH1gPbz2Szag1mLBBAGS',
-    bagsUrl: 'https://bags.fm/coin/GefTGjFnJGW9PM93Ycb5RrHKiH1gPbz2Szag1mLBBAGS',
+    bagsUrl: 'https://bags.fm/GefTGjFnJGW9PM93Ycb5RrHKiH1gPbz2Szag1mLBBAGS',
   },
   treasury: {
     wallet: '2FCwMoEYKFVe93FNMApYtwCEdCboCPEYnS5JSjvw6kRZ',


### PR DESCRIPTION
## Summary
Updated the bags.fm URLs in token configuration to use the simplified URL format without the `/coin` path segment.

## Changes
- Updated the bagsUrl template in `src/app/framework/page.tsx` from `https://bags.fm/coin/<address>` to `https://bags.fm/<address>`
- Updated the bagsUrl in `src/giggybank.config.ts` from `https://bags.fm/coin/GefTGjFnJGW9PM93Ycb5RrHKiH1gPbz2Szag1mLBBAGS` to `https://bags.fm/GefTGjFnJGW9PM93Ycb5RrHKiH1gPbz2Szag1mLBBAGS`

## Details
This change reflects an update to the bags.fm API/URL structure, removing the `/coin` path component from token detail URLs. The token address remains the same; only the URL path has been simplified.