### PR TITLE
Replace iOS App link with Coming Soon placeholder

### DIFF
--- a/src/components/layout/SiteFooter.tsx
+++ b/src/components/layout/SiteFooter.tsx
@@ -79,19 +79,14 @@ export default function SiteFooter() {
                   </a>
                 </li>
               )}
-              {config.appStoreUrl && (
-                <li>
-                  <a
-                    href={config.appStoreUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-flex items-center gap-1 text-zinc-400 transition-colors hover:text-white"
-                  >
-                    iOS App
-                    <span className="text-zinc-600">↗</span>
-                  </a>
-                </li>
-              )}
+              <li>
+                <span
+                  title="Coming Soon"
+                  className="inline-flex cursor-default items-center gap-1 text-zinc-600"
+                >
+                  iOS App
+                </span>
+              </li>
             </ul>
           </div>
 


### PR DESCRIPTION
## Summary
Updated the SiteFooter component to replace the functional iOS App store link with a disabled "Coming Soon" placeholder, indicating that the iOS app is not yet available.

## Key Changes
- Removed the conditional rendering of the iOS App store link that pointed to `config.appStoreUrl`
- Replaced the interactive link with a static `<span>` element displaying "iOS App"
- Added a "Coming Soon" tooltip via the `title` attribute
- Updated styling to reflect disabled state:
  - Changed from `text-zinc-400 hover:text-white` to `text-zinc-600`
  - Removed hover transition effects
  - Added `cursor-default` to indicate non-interactive element
  - Removed the external link indicator (↗ symbol)

## Implementation Details
The iOS App link is now a visual placeholder rather than a functional link, signaling to users that this feature is under development without requiring configuration changes to remove the link entirely.