### PR TITLE
Reorder landing page sections: move hackathon tweet earlier

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -67,6 +67,15 @@ export default function LandingPage() {
         </div>
       </section>
 
+      {/* Hackathon Tweet */}
+      <section className="border-b border-zinc-800 px-4 py-16">
+        <div className="mx-auto max-w-xl">
+          <div className="flex justify-center rounded-xl bg-white p-4" data-theme="light">
+            <Tweet id="2033733353019765129" />
+          </div>
+        </div>
+      </section>
+
       {/* How it works */}
       <section className="border-b border-zinc-800 px-4 py-20">
         <div className="mx-auto max-w-4xl">
@@ -133,15 +142,6 @@ export default function LandingPage() {
         >
           Verify treasury on Solscan <ArrowRight size={14} />
         </a>
-      </section>
-
-      {/* Hackathon Tweet */}
-      <section className="border-t border-zinc-800 px-4 py-16">
-        <div className="mx-auto max-w-xl">
-          <div className="flex justify-center rounded-xl bg-white p-4" data-theme="light">
-            <Tweet id="2033733353019765129" />
-          </div>
-        </div>
       </section>
 
       <SiteFooter />


### PR DESCRIPTION
## Summary
Reorganized the landing page layout by moving the "Hackathon Tweet" section to appear earlier in the page flow, positioning it between the initial section and the "How it works" section.

## Changes
- Moved the Hackathon Tweet section from its original position (after the CTA section, before the footer) to an earlier position in the page hierarchy
- The section now appears after the initial featured section and before the "How it works" section
- Updated the border styling from `border-t` (top border) to `border-b` (bottom border) to maintain visual consistency with surrounding sections
- No changes to the component's internal structure or styling

## Details
This reordering improves the page flow by showcasing social proof (the hackathon tweet) earlier in the user's journey, potentially increasing engagement before users reach the detailed "How it works" section.
