### PR TITLE
Update CoinGecko URL to use token address lookup

### DIFF
--- a/src/giggybank.config.ts
+++ b/src/giggybank.config.ts
@@ -16,7 +16,7 @@ export const config: ProjectConfig = {
     address: 'GefTGjFnJGW9PM93Ycb5RrHKiH1gPbz2Szag1mLBBAGS',
     bagsUrl: 'https://bags.fm/GefTGjFnJGW9PM93Ycb5RrHKiH1gPbz2Szag1mLBBAGS',
     dexScreenerUrl: 'https://dexscreener.com/solana/GefTGjFnJGW9PM93Ycb5RrHKiH1gPbz2Szag1mLBBAGS',
-    coingeckoUrl: 'https://www.coingecko.com/en/coins/giggybank',
+    coingeckoUrl: 'https://www.coingecko.com/en/coins/by-token-address/solana/GefTGjFnJGW9PM93Ycb5RrHKiH1gPbz2Szag1mLBBAGS',
   },
   treasury: {
     wallet: '2FCwMoEYKFVe93FNMApYtwCEdCboCPEYnS5JSjvw6kRZ',


### PR DESCRIPTION
## Summary
Updated the CoinGecko URL configuration to use the token address-based lookup endpoint instead of the generic coin slug endpoint.

## Changes
- Modified `coingeckoUrl` in the giggybank config to point to the token-specific CoinGecko page using the Solana token address (`GefTGjFnJGW9PM93Ycb5RrHKiH1gPbz2Szag1mLBBAGS`)
- Changed from: `https://www.coingecko.com/en/coins/giggybank`
- Changed to: `https://www.coingecko.com/en/coins/by-token-address/solana/GefTGjFnJGW9PM93Ycb5RrHKiH1gPbz2Szag1mLBBAGS`

## Details
This change ensures the configuration links directly to the token's CoinGecko page via its blockchain address, which is more reliable and specific than relying on the coin slug. This approach prevents potential issues if the coin slug changes or if there are multiple entries with similar names.

https://claude.ai/code/session_012rT6ejgZTgv8kfvSvXJw4G