### PR TITLE
Add GitHub repository link to site footer

### DIFF
--- a/src/components/layout/SiteFooter.tsx
+++ b/src/components/layout/SiteFooter.tsx
@@ -102,6 +102,17 @@ export default function SiteFooter() {
                 </li>
               )}
               <li>
+                <a
+                  href="https://github.com/jsigwart/impacttreasury-giggybank"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 text-zinc-400 transition-colors hover:text-white"
+                >
+                  GitHub
+                  <span className="text-zinc-600">↗</span>
+                </a>
+              </li>
+              <li>
                 <span
                   title="Coming Soon"
                   className="inline-flex cursor-default items-center gap-1 text-zinc-600"


### PR DESCRIPTION
## Summary
Added a GitHub repository link to the site footer navigation, allowing users to easily access the project's source code.

## Changes
- Added a new footer link pointing to the impacttreasury-giggybank GitHub repository
- Link opens in a new tab with proper security attributes (`target="_blank"` and `rel="noopener noreferrer"`)
- Styled consistently with existing footer links using the same hover and color transitions
- Includes an external link indicator (↗) matching the design pattern of other footer links

## Implementation Details
- Positioned before the "Coming Soon" placeholder item in the footer navigation
- Uses the same styling classes as adjacent links for visual consistency
- Properly configured for accessibility and security best practices