### PR TITLE
Add TikTok social media link to site footer

### DIFF
--- a/src/components/layout/SiteFooter.tsx
+++ b/src/components/layout/SiteFooter.tsx
@@ -101,6 +101,19 @@ export default function SiteFooter() {
                   </a>
                 </li>
               )}
+              {config.social.tiktok && (
+                <li>
+                  <a
+                    href={config.social.tiktok}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1 text-zinc-400 transition-colors hover:text-white"
+                  >
+                    TikTok
+                    <span className="text-zinc-600">↗</span>
+                  </a>
+                </li>
+              )}
               <li>
                 <span
                   title="Coming Soon"

--- a/src/giggybank.config.ts
+++ b/src/giggybank.config.ts
@@ -31,6 +31,7 @@ export const config: ProjectConfig = {
   social: {
     twitter: 'https://twitter.com/giggybank',
     telegram: '',
+    tiktok: 'https://www.tiktok.com/@giggybank',
   },
   appStoreUrl: 'https://apps.apple.com/app/giggybank/PLACEHOLDER',
   mint: {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -23,6 +23,7 @@ export interface ProjectConfig {
   social: {
     twitter: string
     telegram: string
+    tiktok: string
   }
   appStoreUrl: string
   mint: {


### PR DESCRIPTION
## Summary
Added TikTok social media support to the site footer, allowing users to access the project's TikTok profile from the footer navigation.

## Key Changes
- **Type Definition**: Added `tiktok` field to the `ProjectConfig.social` interface in `src/types/index.ts`
- **Configuration**: Added TikTok URL (`https://www.tiktok.com/@giggybank`) to the social media configuration in `src/giggybank.config.ts`
- **UI Component**: Implemented conditional rendering of TikTok link in `SiteFooter.tsx` with consistent styling matching existing social media links

## Implementation Details
- The TikTok link follows the same pattern as other social media links (Twitter, Telegram) with conditional rendering based on config value
- Styling is consistent with existing social links: zinc-400 text color with white hover state and external link indicator (↗)
- Link opens in a new tab with `target="_blank"` and `rel="noopener noreferrer"` for security