### PR TITLE
Remove token symbol badge from site header

### DIFF
--- a/src/components/layout/SiteHeader.tsx
+++ b/src/components/layout/SiteHeader.tsx
@@ -15,14 +15,6 @@ export default function SiteHeader() {
           <Link href="/" className="text-lg font-bold tracking-tight text-white">
             {config.name}
           </Link>
-          <a
-            href={config.token.bagsUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="rounded bg-green-400/10 px-1.5 py-0.5 text-xs font-semibold text-green-400 transition-colors hover:bg-green-400/20"
-          >
-            {config.token.symbol}
-          </a>
         </div>
 
         {/* Desktop nav */}


### PR DESCRIPTION
## Summary
Removed the token symbol badge display from the site header navigation.

## Changes
- Removed the token symbol link badge that was displayed next to the site name in the header
- This badge previously linked to `config.token.bagsUrl` and displayed `config.token.symbol` with green styling

## Details
The token symbol badge component has been completely removed from the SiteHeader. This was a styled anchor element with green background and text colors that provided a link to the token's external URL. The removal simplifies the header layout and reduces the prominence of token-related information in the navigation area.