### PR TITLE
Remove About and Framework navigation links from header

### DIFF
--- a/src/components/layout/SiteHeader.tsx
+++ b/src/components/layout/SiteHeader.tsx
@@ -33,18 +33,6 @@ export default function SiteHeader() {
           >
             Mint
           </Link>
-          <Link
-            href="/about"
-            className="text-sm text-zinc-400 transition-colors hover:text-white"
-          >
-            About
-          </Link>
-          <Link
-            href="/framework"
-            className="text-sm text-zinc-400 transition-colors hover:text-white"
-          >
-            Framework
-          </Link>
           <a
             href={config.token.bagsUrl}
             target="_blank"
@@ -75,20 +63,6 @@ export default function SiteHeader() {
               className="text-sm text-zinc-400 transition-colors hover:text-white"
             >
               Mint
-            </Link>
-            <Link
-              href="/about"
-              onClick={() => setMenuOpen(false)}
-              className="text-sm text-zinc-400 transition-colors hover:text-white"
-            >
-              About
-            </Link>
-            <Link
-              href="/framework"
-              onClick={() => setMenuOpen(false)}
-              className="text-sm text-zinc-400 transition-colors hover:text-white"
-            >
-              Framework
             </Link>
             <a
               href={config.token.bagsUrl}


### PR DESCRIPTION
## Summary
Removed the "About" and "Framework" navigation links from the site header in both desktop and mobile menu implementations.

## Changes
- Removed "About" link (`/about`) from the desktop navigation menu
- Removed "Framework" link (`/framework`) from the desktop navigation menu
- Removed "About" link from the mobile menu navigation
- Removed "Framework" link from the mobile menu navigation

## Details
The changes affect the `SiteHeader` component, removing 4 Link components (2 from desktop nav, 2 from mobile nav) while keeping the "Mint" link and external token bags link intact. The mobile menu versions also included `onClick={() => setMenuOpen(false)}` handlers which are no longer needed for these removed links.
