### PR TITLE
Add Discord link to site footer

### DIFF
--- a/src/components/layout/SiteFooter.tsx
+++ b/src/components/layout/SiteFooter.tsx
@@ -153,6 +153,17 @@ export default function SiteFooter() {
                   <span className="text-zinc-600">↗</span>
                 </a>
               </li>
+              <li>
+                <a
+                  href="https://discord.gg/giggybank"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 text-zinc-400 transition-colors hover:text-white"
+                >
+                  Discord
+                  <span className="text-zinc-600">↗</span>
+                </a>
+              </li>
             </ul>
           </div>
         </div>


### PR DESCRIPTION
## Summary
Added a Discord community link to the site footer, allowing users to easily access the GiggyBank Discord server.

## Changes
- Added a new footer link item pointing to the GiggyBank Discord server (https://discord.gg/giggybank)
- Styled the link consistently with existing footer links using the same classes for hover effects and external link indicators
- Link opens in a new tab with proper security attributes (`target="_blank"` and `rel="noopener noreferrer"`)

## Implementation Details
- The Discord link follows the same pattern as other footer links with an external link indicator (↗)
- Uses consistent styling with `text-zinc-400` base color and `hover:text-white` transition
- Positioned as the last item in the footer links list