### PR TITLE
fix: correct project's twitter / x url 

### DIFF
--- a/src/giggybank.config.ts
+++ b/src/giggybank.config.ts
@@ -29,7 +29,7 @@ export const config: ProjectConfig = {
     accentColor: '#4ade80',
   },
   social: {
-    twitter: 'https://twitter.com/giggybank',
+    twitter: 'https://x.com/jsigwart',
     telegram: '',
     tiktok: 'https://www.tiktok.com/@giggybank',
   },


### PR DESCRIPTION
## Summary

the twitter that was linked is incorrect / project does not own

changed to the founder's twitter for now

## Changes
- Updated Twitter social link from `https://twitter.com/giggybank` to `https://x.com/jsigwart` in the project configuration
