### PR TITLE
fix: prevent icon stretching in "How it works" cards

### DIFF
--- a/src/app/framework/page.tsx
+++ b/src/app/framework/page.tsx
@@ -107,7 +107,7 @@ export default function FrameworkPage() {
                   body: 'Every published campaign is fully public — with a receipt, an on-chain tx you can verify on Solscan, and an optional social post. Nothing gets posted until it can be proven.',
                 },
               ].map(({ icon: Icon, title, body }) => (
-                <div key={title} className="flex gap-3 rounded-xl border border-zinc-800 bg-zinc-900 p-5">
+                <div key={title} className="flex items-start gap-3 rounded-xl border border-zinc-800 bg-zinc-900 p-5">
                   <div className="mt-0.5 shrink-0 rounded-lg bg-zinc-800 p-1.5">
                     <Icon size={16} className="text-zinc-400" />
                   </div>


### PR DESCRIPTION
### Before
<img width="1124" height="1234" alt="Screenshot 2026-03-22 at 9 28 20 PM" src="https://github.com/user-attachments/assets/b258c957-882e-47ee-80d3-06ee22977189" />

### After
<img width="988" height="1080" alt="Screenshot 2026-03-22 at 9 28 09 PM" src="https://github.com/user-attachments/assets/b61f7048-2c90-4fc7-864e-97b8a9416106" />
