### PR TITLE
Reorganize footer sections and update color scheme

### DIFF
--- a/src/app/framework/page.tsx
+++ b/src/app/framework/page.tsx
@@ -107,7 +107,7 @@ export default function FrameworkPage() {
                   body: 'Every published campaign is fully public — with a receipt, an on-chain tx you can verify on Solscan, and an optional social post. Nothing gets posted until it can be proven.',
                 },
               ].map(({ icon: Icon, title, body }) => (
-                <div key={title} className="flex gap-3 rounded-xl border border-zinc-800 bg-zinc-900 p-5">
+                <div key={title} className="flex items-start gap-3 rounded-xl border border-zinc-800 bg-zinc-900 p-5">
                   <div className="mt-0.5 shrink-0 rounded-lg bg-zinc-800 p-1.5">
                     <Icon size={16} className="text-zinc-400" />
                   </div>

--- a/src/components/layout/SiteFooter.tsx
+++ b/src/components/layout/SiteFooter.tsx
@@ -20,10 +20,10 @@ export default function SiteFooter() {
             </p>
           </div>
 
-          {/* Navigate */}
+          {/* Explore */}
           <div>
-            <h4 className="mb-4 text-xs font-semibold uppercase tracking-widest text-gray-500">
-              Navigate
+            <h4 className="mb-4 text-xs font-semibold uppercase tracking-widest text-zinc-500">
+              Explore
             </h4>
             <ul className="space-y-2.5 text-sm">
               <li>
@@ -49,10 +49,67 @@ export default function SiteFooter() {
             </ul>
           </div>
 
-          {/* External */}
+          {/* Connect */}
           <div>
-            <h4 className="mb-4 text-xs font-semibold uppercase tracking-widest text-gray-500">
-              External
+            <h4 className="mb-4 text-xs font-semibold uppercase tracking-widest text-zinc-500">
+              Connect
+            </h4>
+            <ul className="space-y-2.5 text-sm">
+              {config.social.twitter && (
+                <li>
+                  <a
+                    href={config.social.twitter}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1 text-zinc-400 transition-colors hover:text-white"
+                  >
+                    Twitter
+                    <span className="text-zinc-600">↗</span>
+                  </a>
+                </li>
+              )}
+              {config.social.tiktok && (
+                <li>
+                  <a
+                    href={config.social.tiktok}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1 text-zinc-400 transition-colors hover:text-white"
+                  >
+                    TikTok
+                    <span className="text-zinc-600">↗</span>
+                  </a>
+                </li>
+              )}
+              <li>
+                <a
+                  href="https://discord.gg/giggybank"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 text-zinc-400 transition-colors hover:text-white"
+                >
+                  Discord
+                  <span className="text-zinc-600">↗</span>
+                </a>
+              </li>
+              <li>
+                <a
+                  href="https://github.com/jsigwart/impacttreasury-giggybank"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 text-zinc-400 transition-colors hover:text-white"
+                >
+                  GitHub
+                  <span className="text-zinc-600">↗</span>
+                </a>
+              </li>
+            </ul>
+          </div>
+
+          {/* Resources */}
+          <div>
+            <h4 className="mb-4 text-xs font-semibold uppercase tracking-widest text-zinc-500">
+              Resources
             </h4>
             <ul className="space-y-2.5 text-sm">
               <li>
@@ -88,60 +145,6 @@ export default function SiteFooter() {
                   <span className="text-gray-400">↗</span>
                 </a>
               </li>
-              {config.social.twitter && (
-                <li>
-                  <a
-                    href={config.social.twitter}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-flex items-center gap-1 text-gray-600 transition-colors hover:text-slate-900"
-                  >
-                    Twitter
-                    <span className="text-gray-400">↗</span>
-                  </a>
-                </li>
-              )}
-              {config.social.tiktok && (
-                <li>
-                  <a
-                    href={config.social.tiktok}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-flex items-center gap-1 text-gray-600 transition-colors hover:text-slate-900"
-                  >
-                    TikTok
-                    <span className="text-gray-400">↗</span>
-                  </a>
-                </li>
-              )}
-              <li>
-                <a
-                  href="https://github.com/jsigwart/impacttreasury-giggybank"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1 text-gray-600 transition-colors hover:text-slate-900"
-                >
-                  GitHub
-                  <span className="text-gray-400">↗</span>
-                </a>
-              </li>
-              <li>
-                <span
-                  title="Coming Soon"
-                  className="inline-flex cursor-default items-center gap-1 text-gray-400"
-                >
-                  iOS App
-                </span>
-              </li>
-            </ul>
-          </div>
-
-          {/* Community */}
-          <div>
-            <h4 className="mb-4 text-xs font-semibold uppercase tracking-widest text-gray-500">
-              Community
-            </h4>
-            <ul className="space-y-2.5 text-sm">
               <li>
                 <a
                   href={config.token.bagsUrl}
@@ -150,17 +153,6 @@ export default function SiteFooter() {
                   className="inline-flex items-center gap-1 text-gray-600 transition-colors hover:text-slate-900"
                 >
                   Bags.fm
-                  <span className="text-gray-400">↗</span>
-                </a>
-              </li>
-              <li>
-                <a
-                  href="https://discord.gg/giggybank"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1 text-gray-600 transition-colors hover:text-slate-900"
-                >
-                  Discord
                   <span className="text-gray-400">↗</span>
                 </a>
               </li>


### PR DESCRIPTION
## Summary
Restructured the site footer to reorganize link sections and updated the color palette from gray to zinc for better visual consistency.

## Key Changes

### Footer Section Reorganization
- Renamed "Navigate" section to "Explore"
- Renamed "External" section to "Connect" and moved social links (Twitter, TikTok, Discord, GitHub) here
- Renamed "Community" section to "Resources" and moved token/treasury links (Treasury, DexScreener, CoinGecko, Bags.fm) here
- Removed the "iOS App" placeholder link from the Connect section

### Color Scheme Updates
- Updated heading colors from `text-gray-500` to `text-zinc-500` across all footer sections
- Updated social link colors in the Connect section:
  - Link text: `text-gray-600` → `text-zinc-400`
  - Hover state: `hover:text-slate-900` → `hover:text-white`
  - Arrow icon: `text-gray-400` → `text-zinc-600`
- Kept Resources section links with original gray color scheme for consistency with other footer content

### Minor Layout Fix
- Added `items-start` class to framework page feature cards to properly align icons with text content

## Implementation Details
The reorganization groups related links more logically: social/community connections in "Connect" and token/market data in "Resources". The color updates modernize the footer appearance while maintaining visual hierarchy and readability.

https://claude.ai/code/session_018XghiJjsEKSgzjurCpmvAK