### PR TITLE
Remove broken dashboard link from footer

### DIFF
--- a/src/components/layout/SiteFooter.tsx
+++ b/src/components/layout/SiteFooter.tsx
@@ -37,11 +37,6 @@ export default function SiteFooter() {
                 </Link>
               </li>
               <li>
-                <Link href="/dashboard" className="text-gray-600 transition-colors hover:text-slate-900">
-                  Dashboard
-                </Link>
-              </li>
-              <li>
                 <Link href="/framework" className="text-gray-600 transition-colors hover:text-slate-900">
                   Framework
                 </Link>


### PR DESCRIPTION
## Summary
- Removed the non-functional `/dashboard` link from the site footer in `SiteFooter.tsx`

## Test plan
- [ ] Verify the footer renders correctly without the dashboard link
- [ ] Confirm remaining footer links (Whitepaper, Mint, Framework, About) still work

https://claude.ai/code/session_016CMRhDrwc6vmfhFqYKgML7