### PR TITLE
Fix GiggyBank TikTok link

### DIFF
--- a/src/giggybank.config.ts
+++ b/src/giggybank.config.ts
@@ -31,7 +31,7 @@ export const config: ProjectConfig = {
   social: {
     twitter: 'https://x.com/jsigwart',
     telegram: '',
-    tiktok: 'https://www.tiktok.com/@giggybank',
+    tiktok: 'https://www.tiktok.com/@giggybankapp',
   },
   appStoreUrl: 'https://apps.apple.com/app/giggybank/PLACEHOLDER',
   mint: {


### PR DESCRIPTION
## Summary
- Fix TikTok social link from `@giggybank` to `@giggybankapp` in site config

## Test plan
- [ ] Verify the TikTok link in the site footer navigates to the correct profile